### PR TITLE
Clean up parsers

### DIFF
--- a/bin/train_spark.sh
+++ b/bin/train_spark.sh
@@ -75,7 +75,7 @@ SPARK_COMMAND="$exec_env && spark-submit --num-executors 10 \
     --conf spark.executorEnv.HOME=${SPARK_ENV_HOME} \
     --py-files $DEPENDENT_PY_FILES \
     ${MAIN_TRAIN_SCRIPT} \
-    --train_imgs_path ${training_file} --train --train_mode spark --config_file ${CONFIGURATION_FILE} \
+    --train-imgs-path ${training_file} --train --train-mode spark --config-file ${CONFIGURATION_FILE} \
     >${working_dir}/train.log 2>&1"
 
 echo "Spark Command: $SPARK_COMMAND"

--- a/docs/luna.md
+++ b/docs/luna.md
@@ -3,5 +3,5 @@
 - Start training in standalone mode
 ```
 $ cd ~/Developer/ggo
-$ python -m scripts.luna.LUNA_train --train_path <train_path> --val_path <val_path> --config_file config/luna/model_1_theano.ini
+$ python -m scripts.luna.LUNA_train -t <train_path> -v <val_path> -c config/luna/model_1_theano.ini
 ```

--- a/docs/train.md
+++ b/docs/train.md
@@ -2,5 +2,5 @@
 - Modify the configuration file as needed. The configuration file is in config/config.ini.
 - Start training in standalone mode
 ```
-$ scripts/train.py --train --train_mode standalone --train_imgs_path <path to the train img file> --config_file config/config.ini
+$ scripts/train.py --train --train_mode standalone --train-imgs-path <path to the train img file> --config-file config/config.ini
 ```

--- a/scripts/data.py
+++ b/scripts/data.py
@@ -17,13 +17,13 @@ logging_handler_out = logging.StreamHandler(sys.stdout)
 logger.addHandler(logging_handler_out)
 
 
-def parse_options():
+def get_parser():
     parser = argparse.ArgumentParser(description='Merge DICOM Images.')
-    parser.add_argument('--input_dir', metavar='input_dir', nargs='?',
+    parser.add_argument('-i', '--input-dir', nargs='?', required=True,
                         help='input directory for source images')
-    parser.add_argument('--mask_input_dir', metavar='mask_input_dir', nargs='?',
+    parser.add_argument('-m', '--mask-input-dir', nargs='?', required=True,
                         help='input directory for mask images')
-    parser.add_argument('--output_dir', metavar='output_dir', nargs='?',
+    parser.add_argument('-o', '--output-dir', nargs='?', required=True,
                         help='output directory')
 
     return parser.parse_args()
@@ -60,7 +60,7 @@ def save(img_file, directory):
     shutil.copy2(img_file, directory)
 
 if __name__ == '__main__':
-    args = parse_options()
+    args = get_parser()
     img_dir = os.path.abspath(os.path.join(args.input_dir, 'DICOMDAT'))
     mask_dir = os.path.abspath(args.mask_input_dir)
     file_paths = get_filepaths(img_dir)

--- a/scripts/data_proc.py
+++ b/scripts/data_proc.py
@@ -350,14 +350,14 @@ def get_filepaths(directory):
     return file_paths  # Self-explanatory.
 
 
-def parse_options():
+def get_parser():
     parser = argparse.ArgumentParser(description='Process DICOM Images.')
-    parser.add_argument('--input_dirs', metavar='input_dirs', nargs='+',
-                        help='input directory for source images and masks', required=True)
-    parser.add_argument('--output_file', metavar='output_file', nargs='?',
-                        help='output file', required=True)
-    parser.add_argument('--config_file', metavar='config_file', nargs='?',
-                        help='config file', required=True)
+    parser.add_argument('-i', '--input-dirs', nargs='+', required=True,
+                        help='input directory for source images and masks')
+    parser.add_argument('-o', '--output-file', nargs='?', required=True,
+                        help='output file')
+    parser.add_argument('-c', '--config-file', nargs='?', required=True,
+                        help='config file')
 
     return parser.parse_args()
 
@@ -635,7 +635,7 @@ def clustering(imgs, ggo_flag):
     return ix
 
 if __name__ == '__main__':
-    args = parse_options()
+    args = get_parser()
 
     config = ConfigParser.ConfigParser()
     config.read(args.config_file)

--- a/scripts/ec2/ec2_launcher.py
+++ b/scripts/ec2/ec2_launcher.py
@@ -23,15 +23,13 @@ logger.addHandler(logging_handler_out)
 
 def get_parser():
     parser = argparse.ArgumentParser(description='launch task from ec2')
-    parser.add_argument('--dburl', metavar='dburl', nargs='?',
+    parser.add_argument('-d', '--dburl', nargs='?', required=True,
                         help='the mysql db url')
     return parser
 
 if __name__ == '__main__':
     parser = get_parser()
     args = parser.parse_args()
-    if not args.dburl:
-        parser.error('Required to set --dburl')
 
     engine = create_engine(args.dburl)
 
@@ -80,7 +78,7 @@ if __name__ == '__main__':
     config_file = data_config.get('config_file')
     config_file = os.path.join(working_dir, config_file)
 
-    prog_args = ['--train_path', train_path, '--val_path', val_path, '--config_file', config_file]
+    prog_args = ['--train-path', train_path, '--val-path', val_path, '--config-file', config_file]
     logger.info('Preparing for main program arguments [%s]' % ','.join(map(str, prog_args)))
 
     # launch main program

--- a/scripts/kaggle/nodule_detection.py
+++ b/scripts/kaggle/nodule_detection.py
@@ -84,13 +84,13 @@ def predict(model_id, model_weights, input_path, output_path):
 
 def get_parser():
     parser = argparse.ArgumentParser(description='Prediction.')
-    parser.add_argument('--input_path', metavar='input_path', nargs='?',
+    parser.add_argument('-i', '--input-path', nargs='?', required=True,
                         help='test data directory containing numpy formatted images and masks in the test set')
-    parser.add_argument('--model_id', metavar='model_id', nargs='?', type=int,
+    parser.add_argument('-m', '--model-id', nargs='?', type=int, required=True,
                         help='model_id')
-    parser.add_argument('--model_weights', metavar='model_weights', nargs='?',
+    parser.add_argument('-w', '--model-weights', nargs='?', required=True,
                         help='trained model weights file')
-    parser.add_argument('--output_path', metavar='output_path', nargs='?',
+    parser.add_argument('-o', '--output-path', nargs='?', required=True,
                         help='output directory to store predition ')
     return parser
 
@@ -99,12 +99,6 @@ if __name__ == '__main__':
     args = parser.parse_args()
 
     print(args)
-
-    if not args.model_id:
-        parser.error('Required to set --model_id')
-
-    if not args.input_path:
-        parser.error('Required to set --test_path')
 
     predict(model_id=args.model_id, model_weights=args.model_weights,
             input_path=args.input_path, output_path=args.output_path)

--- a/scripts/luna/LUNA_train.py
+++ b/scripts/luna/LUNA_train.py
@@ -150,11 +150,11 @@ def train_and_predict(use_existing, train_path, val_path, train_config):
 def get_parser():
     parser = argparse.ArgumentParser(description='Train model.')
 
-    parser.add_argument('--train_path', metavar='train_path', nargs='?', required=True,
+    parser.add_argument('-t', '--train-path', nargs='?', required=True,
                         help='train data directory containing numpy formatted images and masks in the training set')
-    parser.add_argument('--val_path', metavar='val_path', nargs='?',
+    parser.add_argument('-v', '--val-path', nargs='?', required=True,
                         help='val data directory containing numpy formatted images and masks in the val set')
-    parser.add_argument('--config_file', metavar='config_file', nargs='?', required=True,
+    parser.add_argument('-c', '--config-file', nargs='?', required=True,
                         help='config file for your training and prediction')
     return parser
 
@@ -164,15 +164,6 @@ def main(prog_args):
     args = parser.parse_args(prog_args)
 
     print(args)
-
-    if not args.config_file:
-        parser.error('Required to set --config_file')
-
-    if not args.train_path:
-        parser.error('Required to set --train_path')
-
-    if not args.val_path:
-        parser.error('Required to set --val_path')
 
     config = ConfigParser.ConfigParser()
     config.read(args.config_file)

--- a/scripts/luna/watershed_processing.py
+++ b/scripts/luna/watershed_processing.py
@@ -10,9 +10,9 @@ from watershed import load_scan, get_pixels_hu, seperate_lungs
 
 def get_parser():
     parser = argparse.ArgumentParser(description='watershed data')
-    parser.add_argument('--input_dir', metavar='input_dir', nargs='?',
+    parser.add_argument('-i', '--input-dir', nargs='?', required=True,
                         help='input directory')
-    parser.add_argument('--output_path', metavar='output_path', nargs='?',
+    parser.add_argument('-o', '--output-path', nargs='?', required=True,
                         help='output path directory')
     return parser
 
@@ -21,12 +21,6 @@ if __name__ == '__main__':
     args = parser.parse_args()
 
     print(args)
-
-    if not args.input_dir:
-        parser.error('Required to set --input_dir')
-
-    if not args.input_dir:
-        parser.error('Required to set --output_path')
 
     input_dir = args.input_dir
     output_path = args.output_path

--- a/scripts/train.py
+++ b/scripts/train.py
@@ -402,19 +402,21 @@ def predict(model_file_path, test_imgs_path, config):
 
 def get_parser():
     parser = argparse.ArgumentParser(description='Train model.')
-    parser.add_argument('--train', dest='train',
-                        action='store_true', help='train the model')
-    parser.add_argument('--train_imgs_path', metavar='train_imgs_path', nargs='?',
-                        help='input HD5 file for images and masks in the training set')
-    parser.add_argument('--train_mode', metavar='train_mode', nargs='?',
-                        help='mode to train your model, can be either spark or standalone')
-    parser.add_argument('--config_file', metavar='config_file', nargs='?',
+    parser.add_argument('--config-file', nargs='?', required=True,
                         help='config file for your training and prediction')
-    parser.add_argument('--predict', dest='predict',
+    group = parser.add_mutually_exclusive_group(required=True)
+    group.add_argument('--train', dest='train',
+                        action='store_true', help='train the model')
+    parser.add_argument('--train-imgs-path', metavar='train_imgs_path', nargs='?',
+                        help='input HD5 file for images and masks in the training set')
+    parser.add_argument('--train-mode', nargs='?',
+                        help='mode to train your model, can be either spark or standalone')
+
+    group.add_argument('--predict', dest='predict',
                         action='store_true', help='predict the model')
-    parser.add_argument('--test_imgs_path', metavar='test_imgs_path', nargs='?',
+    parser.add_argument('--test-imgs-path', nargs='?',
                         help='input HD5 file for images and masks in the test set')
-    parser.add_argument('--model_file_path', metavar='model_file_path', nargs='?',
+    parser.add_argument('--model-file-path', nargs='?',
                         help='the HD5 file to store the model and weights')
 
     return parser
@@ -426,19 +428,13 @@ def main(prog_args):
 
     print(args)
 
-    if not args.train and not args.predict:
-        parser.error('Required to set either --train or --predict option')
-
-    if not args.config_file:
-        parser.error('Required to set --config_file')
-
     if args.train and (args.train_imgs_path is None or args.train_mode is None):
         parser.error(
-            'arguments --train_imgs_path and --train_mode are required when --train is specified')
+            'arguments --train-imgs-path and --train-mode are required when --train is specified')
 
     if args.predict and (args.test_imgs_path is None or args.model_file_path is None):
         parser.error(
-            'arguments --test_imgs_path and --model_file_path are required when --predict is specified')
+            'arguments --test-imgs-path and --model-file-path are required when --predict is specified')
 
     config = ConfigParser.ConfigParser()
     config.read(args.config_file)


### PR DESCRIPTION
See this example:

```
def get_parser():
    parser = argparse.ArgumentParser(description='Prediction.')
    parser.add_argument('--input_path', metavar='input_path', nargs='?',
                        help='test data directory containing numpy formatted images and masks in the test set')
    parser.add_argument('--model_id', metavar='model_id', nargs='?', type=int,
                        help='model_id')
    parser.add_argument('--model_weights', metavar='model_weights', nargs='?',
                        help='trained model weights file')
    parser.add_argument('--output_path', metavar='output_path', nargs='?',
                        help='output directory to store predition ')
    return parser
```

We have to change it like this:

```
def get_parser():
    parser = argparse.ArgumentParser(description='Prediction.')
    parser.add_argument('-i', '--input-path', required=True,
                        help='test data directory containing numpy formatted images and masks in the test set')
    parser.add_argument('-m', '--model_id', required=True, type=int,
                        help='model_id')
    parser.add_argument('-w', '--model_weights', required=True,
                        help='trained model weights file')
    parser.add_argument('-o', '--output_path', required=True,
                        help='output directory to store predition ')
    return parser
```

And remove this code:
```
    if not args.model_id:
        parser.error('Required to set --model_id')

    if not args.input_path:
        parser.error('Required to set --test_path')
```

Do this clean up in all files.

+ Update document for parameter changes.