### PR TITLE
Create symbolic links when partitioning data

### DIFF
--- a/bin/data_processing/partition.sh
+++ b/bin/data_processing/partition.sh
@@ -80,8 +80,8 @@ do
        mkdir -p ${output_dir}/${batch}
    fi
 
-   echo mv ${input_dir}/${files[$i]} ${output_dir}/${batch}
-   mv ${input_dir}/${files[$i]} ${output_dir}/${batch}
+   echo ln -s ${input_dir}/${files[$i]} ${output_dir}/${batch}
+   ln -s ${input_dir}/${files[$i]} ${output_dir}/${batch}
    let i++
 done
 


### PR DESCRIPTION
Don't move input dir to output dir. Instead, make a symbolic link from input dir to output dir.